### PR TITLE
Support zoom: var(--bga-game-zoom); #141388

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,7 +7,10 @@
     <title>Sunrise Sunset - local dev</title>
   </head>
   <body>
-    <div id="app"></div>
+    <div id="overall-content">
+    <!-- <div id="overall-content" style="zoom: 0.75;"> -->
+      <div id="app"></div>
+    </div>
     <script type="module" src="/src/main.ts"></script>
     <script src="/test.js"></script>
   </body>

--- a/src/components/game-card.vue
+++ b/src/components/game-card.vue
@@ -154,13 +154,53 @@ const showDetails = (evt: MouseEvent | TouchEvent) => {
     // wait for render
     const mcElm = document.querySelector('#card-modal-' + props.id);
     const body = document.body;
-    if (!mcElm) {
+    const gcElm = document.getElementById('overall-content');
+    if (!mcElm || !gcElm) {
       return;
     }
     const mcRect = mcElm.getBoundingClientRect();
+    const bdRect = body.getBoundingClientRect();
+    const gcRect = gcElm.getBoundingClientRect();
+    const gapY = gcRect.top;
+    const gapX = gcRect.left;
+
+    // detect zoom
+    const match = /zoom: ?([.0-9]+)/.exec(gcElm.style.cssText);
+    if (match) {
+      // mobile special case
+      const percentage = Number(match[1]);
+
+      const stretchedY =
+        (centerY - gapY) / percentage + gapY - mcRect.height / 2 / percentage;
+      modalTop.value = stretchedY;
+
+      let stretchedX =
+        (centerX - gapX) / percentage + gapX - mcRect.width / 2 / percentage;
+      modalLeft.value = stretchedX > 0 ? stretchedX : 0;
+
+      emit('showDetail', props.id);
+
+      setTimeout(() => {
+        const mcRect2 = mcElm.getBoundingClientRect();
+        const ch = document.body.clientHeight;
+        const cw = document.body.clientWidth;
+        if (ch < mcRect2.bottom) {
+          const adjust = (mcRect2.bottom - ch) / percentage;
+          modalTop.value -= adjust;
+        }
+        if (cw < mcRect2.right) {
+          const adjust = (mcRect2.right - cw) / percentage;
+          modalLeft.value -= adjust;
+        }
+        if (modalLeft.value < 0) {
+          modalLeft.value = 0;
+        }
+      });
+      return;
+    }
+
     let mcTop = centerY - mcRect.height / 2;
     let mcLeft = centerX - mcRect.width / 2;
-    const bdRect = body.getBoundingClientRect();
     if (mcTop + mcRect.height > bdRect.height) {
       mcTop = bdRect.height - mcRect.height;
     }

--- a/src/components/hand.vue
+++ b/src/components/hand.vue
@@ -112,7 +112,13 @@ li {
   transition: margin-left 0.5s;
   transition: margin-right 0.5s;
   border: 2px solid transparent;
+
+  @media screen and (max-width: 800px) {
+    margin-left: -30px;
+    margin-right: -30px;
+  }
 }
+
 .selectable {
   border: 2px solid #00e9eb;
   box-shadow: 0 0 5px 5px rgb(0 233 235 / 50%);
@@ -126,6 +132,11 @@ li {
   margin-right: 30px;
   transition: margin-left 0.5s;
   transition: margin-right 0.5s;
+
+  @media screen and (max-width: 800px) {
+    margin-left: 60px;
+    margin-right: 60px;
+  }
 }
 
 .aura {


### PR DESCRIPTION
From https://boardgamearena.com/bug?id=141388

1. BGA framework uses zoom style to adjust the game content size when window size is not big enough. (set --bga-game-zoom and then refer it by `zoom: var(--bga-game-zoom)`.)
2. While zoom is used, `getBoundingClientRect()` that is used for calculating the card detail position won't return a correct coordinate. (unlike `transform: scale()`).
3. Fixed the issue by extracting `--bga-game-zoom` value from the element to get the percentage, and use it for adjusting the coordinate where zoom is used.

Note: This change is relying on BGA framework to keep using `zoom`. If they change it to use `transform: sccale()`, we need to revert back this change (though I assume it won't happen).