### PR TITLE
Make overlay text thicker border #141284

### DIFF
--- a/src/components/grid.vue
+++ b/src/components/grid.vue
@@ -461,8 +461,10 @@ li.grid-cell.highlighted:not(.selected0, .selected1) {
   color: white;
   font-size: 4em;
   font-weight: bolder;
-  text-stroke: 2px #000;
-  -webkit-text-stroke: 2px #000;
+  text-stroke: 8px #000;
+  -webkit-text-stroke: 8px #000;
+  text-shadow: #000 0 0 20px;
+  paint-order: stroke fill;
 }
 
 .overlay {


### PR DESCRIPTION
From https://boardgamearena.com/bug?id=141284

Make overlay number border thicker + add shade.
By using `paint-order: stroke fill;`, border is now outer border, instead of inner like before.
Ref. https://developer.mozilla.org/en-US/docs/Web/CSS/paint-order

<img width="302" alt="スクリーンショット 2024-10-26 12 56 14" src="https://github.com/user-attachments/assets/f885a581-4f30-4aee-8d10-92ff01540569">
