### PR TITLE
do not translate lane, do not restore score in appropriate timings

### DIFF
--- a/bga_src/backend/sunrisesunset.game.php
+++ b/bga_src/backend/sunrisesunset.game.php
@@ -298,23 +298,29 @@ class SunriseSunset extends Table
       $result['reincarnated_col'] = $reincarnation['col'];
     }
 
-    $sql =
-      'SELECT ' .
-      'score_round round, ' .
-      'score_center_list center_list, ' .
-      'score_day_list day_list, ' .
-      'score_night_list night_list, ' .
-      'score_winner winner' .
-      ' FROM score ORDER BY score_round DESC LIMIT 1';
-    $scores = self::getObjectFromDB($sql);
-    if ($scores) {
-      $result['score'] = [];
-      $dayPlayerID = $this->getDayPlayerID();
-      $nightPlayerID = $this->getNightPlayerID();
-      $result['score']['center'] = explode(',', $scores['center_list']);
-      $result['score'][$dayPlayerID] = explode(',', $scores['day_list']);
-      $result['score'][$nightPlayerID] = explode(',', $scores['night_list']);
-      $result['winner'] = explode(',', $scores['winner']);
+    // return this only end of the round
+    if (
+      $this->getStateName() === 'endRound' ||
+      $this->getStateName() === 'gameEnd'
+    ) {
+      $sql =
+        'SELECT ' .
+        'score_round round, ' .
+        'score_center_list center_list, ' .
+        'score_day_list day_list, ' .
+        'score_night_list night_list, ' .
+        'score_winner winner' .
+        ' FROM score ORDER BY score_round DESC LIMIT 1';
+      $scores = self::getObjectFromDB($sql);
+      if ($scores) {
+        $result['score'] = [];
+        $dayPlayerID = $this->getDayPlayerID();
+        $nightPlayerID = $this->getNightPlayerID();
+        $result['score']['center'] = explode(',', $scores['center_list']);
+        $result['score'][$dayPlayerID] = explode(',', $scores['day_list']);
+        $result['score'][$nightPlayerID] = explode(',', $scores['night_list']);
+        $result['winner'] = explode(',', $scores['winner']);
+      }
     }
 
     // identifier
@@ -1089,7 +1095,6 @@ class SunriseSunset extends Table
     }
 
     self::notifyPlayer($p1, 'score', $msg, [
-      'i18n' => ['lane'],
       'lane' => $lane,
       'scoreA' => $scores[$p2],
       'scoreB' => $scores[$p1],
@@ -1098,7 +1103,6 @@ class SunriseSunset extends Table
     ]);
 
     self::notifyPlayer($p2, 'score', $msg, [
-      'i18n' => ['lane'],
       'lane' => $lane,
       'scoreA' => $scores[$p1],
       'scoreB' => $scores[$p2],


### PR DESCRIPTION
Fix for https://boardgamearena.com/bug?id=141680

1. Do not return score data inappropriate timings. Otherwise restored score data can be used in the end of the round.
2. Do not translate lane in `score` notification. Those are used to in sub.ts.

Regarding 2, currently the some log message has translation for lane and some are not.
This need to be fixed separately.