### PR TITLE
Fix night style leakage

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -541,12 +541,16 @@ defineExpose({
 #player_hand,
 .board.day {
   background-color: rgba(255, 255, 255, 0.7);
-  color: #222;
+  .card-header {
+    color: #222;
+  }
 }
 
 .board.night {
   background-color: rgba(0, 0, 0, 0.3);
-  color: #eee;
+  .card-header {
+    color: #eee;
+  }
 }
 
 .card-header {


### PR DESCRIPTION
Fix for https://boardgamearena.com/bug?id=145376

Degrade from #9 
Since modal is no longer teleported to body, parent style may affect the children.
Fix the style properly scoped.
