### PR TITLE
Fix creep discarding issue

### DIFF
--- a/bga_src/backend/sunrisesunset.game.php
+++ b/bga_src/backend/sunrisesunset.game.php
@@ -1176,6 +1176,7 @@ class SunriseSunset extends Table
           clienttranslate('"Horus/Seth" cannot be discarded.'),
           []
         );
+        return;
       }
 
       // check if it is in the hand
@@ -1192,6 +1193,7 @@ class SunriseSunset extends Table
           ),
           []
         );
+        return;
       }
 
       // discard and draw a card

--- a/src/App.vue
+++ b/src/App.vue
@@ -188,7 +188,7 @@ const restore = () => {
             };
           }),
     });
-    handData.value.selectable?.push(true);
+    handData.value.selectable?.push(false);
   });
 
   // init grid data
@@ -312,7 +312,11 @@ const restore = () => {
       ? Number(gamedata.value.reincarnated_col)
       : null;
 
-  state.refresh();
+  if (state.hasMainState(['mulligan', 'playerTurn', 'reincarnationTurn'])) {
+    state.setSubState('init');
+  } else {
+    state.refresh();
+  }
   sub = new Sub(
     playerID,
     gridData,

--- a/src/logic/state.ts
+++ b/src/logic/state.ts
@@ -523,6 +523,10 @@ class State {
     }
   }
 
+  public hasMainState(mainStateNames: string[]): boolean {
+    return mainStateNames.some((s) => this.current.indexOf(s) === 0);
+  }
+
   private setPlayerGridSelectable(): void {
     const selectable: boolean[][][] = [[[], [], []]];
     for (let i = 0; i < 3; i += 1) {


### PR DESCRIPTION
TODO: Test other restore cases.

1. Fix bug that mulligan allows invalid card to discard (backend).
2. Fix bug that Horus / Seth can be selected as mulligan when game is restored in mulligan phase.